### PR TITLE
Add imu roll & pitch to the tf and pose being published

### DIFF
--- a/laser_ortho_projector/package.xml
+++ b/laser_ortho_projector/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>laser_ortho_projector</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
     The laser_ortho_projector package calculates orthogonal projections of LaserScan messages.
   </description>

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -155,6 +155,8 @@ class LaserScanMatcher
     std::vector<double> a_cos_;
     std::vector<double> a_sin_;
 
+    bool add_imu_roll_pitch_;
+
     sm_params input_;
     sm_result output_;
     LDP prev_ldp_scan_;

--- a/laser_scan_matcher/package.xml
+++ b/laser_scan_matcher/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>laser_scan_matcher</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
     <p>
      An incremental laser scan matcher, using Andrea Censi's Canonical Scan Matcher (CSM) implementation. See <a href="http://censi.mit.edu/software/csm/">the web site</a> for more about CSM. NOTE the CSM library is licensed under the GNU Lesser General Public License v3, whereas the rest of the code is released under the BSD license.

--- a/laser_scan_sparsifier/package.xml
+++ b/laser_scan_sparsifier/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>laser_scan_sparsifier</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
     The laser_scan_sparsifier takes in a LaserScan message and sparsifies it.
   </description>

--- a/laser_scan_splitter/package.xml
+++ b/laser_scan_splitter/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>laser_scan_splitter</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
     The laser_scan_splitter takes in a LaserScan message and splits it into a number of other LaserScan messages. Each of the resulting laser scans can be assigned an arbitrary coordinate frame, and is published on a separate topic.
   </description>

--- a/ncd_parser/package.xml
+++ b/ncd_parser/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>ncd_parser</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
      The ncd_parser package reads in .alog data files from the New College Dataset and broadcasts scan and odometry messages to ROS.
   </description>

--- a/polar_scan_matcher/package.xml
+++ b/polar_scan_matcher/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>polar_scan_matcher</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
     <p>
     A wrapper around Polar Scan Matcher by Albert Diosi and Lindsay Kleeman, used for laser scan registration.

--- a/scan_to_cloud_converter/package.xml
+++ b/scan_to_cloud_converter/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>scan_to_cloud_converter</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>
     Converts LaserScan to PointCloud messages.
   </description>

--- a/scan_tools/package.xml
+++ b/scan_tools/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>scan_tools</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
 
   <description>
     Laser scan processing tools.


### PR DESCRIPTION
This pull request introduces a new feature to the `LaserScanMatcher` class by adding support for IMU roll and pitch data. The changes include the addition of a new parameter and the necessary logic to incorporate IMU orientation into the pose estimation process.

Key changes include:

### New Feature Addition:
* Added a boolean member `add_imu_roll_pitch_` to the `LaserScanMatcher` class to control the use of IMU roll and pitch data (`laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h`).
* Initialized the `add_imu_roll_pitch_` parameter in the `initParams` method (`laser_scan_matcher/src/laser_scan_matcher.cpp`).

### IMU Data Integration:
* Updated the `processScan` method to apply IMU roll and pitch data to the current transform if `add_imu_roll_pitch_` is true and IMU data is available (`laser_scan_matcher/src/laser_scan_matcher.cpp`).

### Pose Calculation Adjustments:
* Modified the pose calculation and publishing logic to use the adjusted transform (`current_transform`) instead of `last_base_in_fixed_` in several places within the `processScan` method:
  * Publishing `Pose2D` messages (`laser_scan_matcher/src/laser_scan_matcher.cpp`).
  * Publishing `PoseStamped` messages (`laser_scan_matcher/src/laser_scan_matcher.cpp`).
  * Publishing `PoseWithCovariance` messages (`laser_scan_matcher/src/laser_scan_matcher.cpp`).
  * Broadcasting transform messages (`laser_scan_matcher/src/laser_scan_matcher.cpp`).